### PR TITLE
Replace leading "#" by "C" for Fortran comments

### DIFF
--- a/Template/LO/SubProcesses/reweight.f
+++ b/Template/LO/SubProcesses/reweight.f
@@ -1793,7 +1793,7 @@ C
       include 'run.inc'
       include 'nexternal.inc'
       include 'coupl.inc'
-#      include 'maxparticles.inc'
+C      include 'maxparticles.inc'
       
       double precision all_p(4*maxdim/3+14,*), all_wgt(*)
       double precision all_q2fact(2,*)


### PR DESCRIPTION
Hi @oliviermattelaer this is a very simple PR.
I suggest using leading "C" or "c" for Fortran comments, while reserving "#" for the C preprocessor.

You can switch on the preprocessor using the "-cpp" option of gfortran
https://gcc.gnu.org/onlinedocs/gfortran/Preprocessing-Options.html

Yes I am afraid I would like to add some #ifdefs even in the Fortran ;-)

Thanks
Andrea
